### PR TITLE
Escape strings when creating descriptions

### DIFF
--- a/src/libs/CSharpToJsonSchema.Generators/Sources.Method.Tools.cs
+++ b/src/libs/CSharpToJsonSchema.Generators/Sources.Method.Tools.cs
@@ -2,6 +2,7 @@
 using CSharpToJsonSchema.Generators.Models;
 using H.Generators.Extensions;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace CSharpToJsonSchema.Generators;
 
@@ -45,7 +46,7 @@ namespace {@interface.Namespace}
             tool = new global::CSharpToJsonSchema.Tool
             {{
                 Name = ""{method.Name}"",
-                Description = ""{method.Description}"",
+                Description = ""{GetDescriptionStringAsValidCSharp(method.Description)}"",
                 Strict = {(method.IsStrict ? "true" : "false")},
                 Parameters = global::CSharpToJsonSchema.SchemaBuilder.ConvertToSchema(global::{@interface.Namespace}.{extensionsClassName}JsonSerializerContext.Default.{method.Name}Args,{"\""}{GetDictionaryString(method)}{"\""}),
             }};

--- a/src/libs/CSharpToJsonSchema.Generators/Sources.Method.Tools.cs
+++ b/src/libs/CSharpToJsonSchema.Generators/Sources.Method.Tools.cs
@@ -2,7 +2,6 @@
 using CSharpToJsonSchema.Generators.Models;
 using H.Generators.Extensions;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace CSharpToJsonSchema.Generators;
 

--- a/src/tests/CSharpToJsonSchema.IntegrationTests/VariousTypesTools.cs
+++ b/src/tests/CSharpToJsonSchema.IntegrationTests/VariousTypesTools.cs
@@ -30,6 +30,15 @@ public interface IVariousTypesTools
     
     [Description("Gets the value")]
     public Task<int> GetValueAsync(CancellationToken cancellationToken = default);
+
+    [Description("Gets the value\nWith multiple lines")]
+    public Task<int> GetValueAsync2(CancellationToken cancellationToken = default);
+
+    [Description("""
+        Gets the value
+        With multiple lines
+        """)]
+    public Task<int> GetValueAsync3(CancellationToken cancellationToken = default);
 }
 
 public class VariousTypesService : IVariousTypesTools
@@ -62,6 +71,16 @@ public class VariousTypesService : IVariousTypesTools
     }
 
     public Task<int> GetValueAsync(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> GetValueAsync2(CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<int> GetValueAsync3(CancellationToken cancellationToken = default)
     {
         throw new NotImplementedException();
     }


### PR DESCRIPTION
Descriptions are just splatted into the generated code wholesale, not fixing up any characters that are invalid C#, such as newlines, backslashes, and the like. These are now appropriately escaped for use in a C# string without errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two new methods, each with multi-line descriptions, to the tools interface in integration tests.

- **Bug Fixes**
  - Improved handling of method descriptions to ensure they are valid C# string literals, enhancing compatibility and reducing formatting errors in generated code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->