### PR TITLE
fix: preserve parse options for AOT compilation compatibility

### DIFF
--- a/src/libs/CSharpToJsonSchema.Generators/Conversion/SymbolGenerator.cs
+++ b/src/libs/CSharpToJsonSchema.Generators/Conversion/SymbolGenerator.cs
@@ -71,16 +71,14 @@ public static class SymbolGenerator
             .AddMembers(ns) // if ns is a NamespaceDeclarationSyntax
             .NormalizeWhitespace();
         
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(originalCompilation.GetLanguageVersion()?? LanguageVersion.Default);
-        var syntaxTree =CSharpSyntaxTree.Create(compilationUnit,parseOptions);
-        //CSharpSyntaxTree.Create(ns.NormalizeWhitespace());
+        // Get parse options from an existing syntax tree to preserve all features (needed for AOT)
+        var parseOptions = originalCompilation.SyntaxTrees.FirstOrDefault()?.Options as CSharpParseOptions
+            ?? CSharpParseOptions.Default.WithLanguageVersion(originalCompilation.GetLanguageVersion() ?? LanguageVersion.Default);
+        var syntaxTree = CSharpSyntaxTree.Create(compilationUnit, parseOptions);
 
         // Now we need to add this syntax tree to a new or existing compilation
-        var assemblyName = "TemporaryAssembly";
         var compilation = originalCompilation
             .AddSyntaxTrees(syntaxTree);
-            //.WithAssemblyName(assemblyName);
-        
 
         // Get the semantic model for our newly added syntax tree
         var semanticModel = compilation.GetSemanticModel(syntaxTree);
@@ -96,43 +94,36 @@ public static class SymbolGenerator
         var classSymbol = semanticModel.GetDeclaredSymbol(classNode) as ITypeSymbol;
         return classSymbol;
     }
-    
+
     public static INamedTypeSymbol? GenerateToolJsonSerializerContext(
         string rootNamespace,
         Compilation originalCompilation)
     {
-        
-        
         // Example: we create a class name
         var className = $"ToolsJsonSerializerContext";
-        
-        
+
         // Build a class declaration
         var classDecl = SyntaxFactory.ClassDeclaration(className)
             .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
             .AddModifiers(SyntaxFactory.Token(SyntaxKind.PartialKeyword));
 
         // We create a compilation unit holding our new class
-        
-        
-
-        var namespaceName =rootNamespace; // choose your own
+        var namespaceName = rootNamespace;
         var ns = SyntaxFactory.NamespaceDeclaration(SyntaxFactory.IdentifierName(namespaceName))
             .AddMembers(classDecl);
 
         var compilationUnit = SyntaxFactory.CompilationUnit()
-            .AddMembers(ns) // if ns is a NamespaceDeclarationSyntax
+            .AddMembers(ns)
             .NormalizeWhitespace();
-        
-        var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(originalCompilation.GetLanguageVersion()?? LanguageVersion.Default);
-        var syntaxTree =CSharpSyntaxTree.Create(compilationUnit,parseOptions);
-        //CSharpSyntaxTree.Create(ns.NormalizeWhitespace());
+
+        // Get parse options from an existing syntax tree to preserve all features (needed for AOT)
+        var parseOptions = originalCompilation.SyntaxTrees.FirstOrDefault()?.Options as CSharpParseOptions
+            ?? CSharpParseOptions.Default.WithLanguageVersion(originalCompilation.GetLanguageVersion() ?? LanguageVersion.Default);
+        var syntaxTree = CSharpSyntaxTree.Create(compilationUnit, parseOptions);
 
         // Now we need to add this syntax tree to a new or existing compilation
-        var assemblyName = "TemporaryAssembly";
         var compilation = originalCompilation
             .AddSyntaxTrees(syntaxTree);
-            //.WithAssemblyName(assemblyName);
         
 
         // Get the semantic model for our newly added syntax tree


### PR DESCRIPTION
  ## Summary
  - Fixed source generator failing with "Inconsistent syntax tree features" error when building projects with `PublishAot` enabled
  - The issue was that `SymbolGenerator.cs` only preserved the language version when creating new syntax trees, but AOT compilation requires other parse options (like `Features`) to be preserved as well

  ## Changes
  - Modified `GenerateParameterBasedClassSymbol` and `GenerateToolJsonSerializerContext` to get full parse options from an existing syntax tree in the compilation
  - Removed unused variables and cleaned up code formatting

  ## Test plan
  - [x] All existing tests pass (19 tests: AotTests, UnitTests, SnapshotTests)
  - [x] AotConsole project now builds successfully with `PublishAot`
  - [x] AotConsole runs without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized parse option handling to reuse existing configuration when available, reducing redundant processing in schema generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->